### PR TITLE
Port to Darwin

### DIFF
--- a/package/build_darwin.sh
+++ b/package/build_darwin.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Copyright 2023 Yahoo Inc.
+# Licensed under the terms of the Apache License 2.0. Please see LICENSE file in project root for terms.
+#
+# Run this script to build pam_sshca.so for darwin (macOS) to
+# _build/darwin/{arch}/pam_sshca.so
+#
+
+set -euo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+SOURCE_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")"/.. &>/dev/null && pwd)
+BUILD_DIR="$SOURCE_DIR/_build"
+
+usage() {
+  cat >&2 <<__USAGE__
+$SCRIPT_NAME: compile pam_sshca.so for darwin (macOS)."
+
+Prerequisites:
+- Go (e.g. brew install go)
+
+Usage: $SCRIPT_NAME [--os-arch {arm64 | amd64 | all}]"
+
+  --os-arch   Architecture name. Default: all"
+__USAGE__
+  exit 1
+}
+
+build() {
+  local arch=$1
+  local output_dir="$BUILD_DIR/darwin/$arch"
+  mkdir -p "$output_dir"
+  local -ra build_args=(
+    -v
+    -o "$output_dir/pam_sshca.so"
+    -buildmode=c-shared
+    "$SOURCE_DIR/cmd/pam_sshca"
+  )
+  echo "GOARCH=$arch GOOS=darwin CGO_ENABLED=1 go build ${build_args[*]}"
+  GOARCH="$arch" GOOS=darwin CGO_ENABLED=1 go build "${build_args[@]}"
+}
+
+ARCHS=()
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --os-arch)
+      if [[ $2 == all ]]; then
+        ARCHS+=(amd64 arm64)
+      else
+        ARCHS+=("$2")
+      fi
+      shift 2
+      ;;
+    *)
+      usage
+      ;;
+  esac
+done
+
+[[ "${#ARCHS[@]}" == 0 ]] && ARCHS=(amd64 arm64)
+
+for arch in "${ARCHS[@]}"; do
+  build "$arch"
+done

--- a/pam/cmdline_darwin.go
+++ b/pam/cmdline_darwin.go
@@ -1,0 +1,67 @@
+// Copyright 2023 Yahoo Inc.
+// Licensed under the terms of the Apache License 2.0. Please see LICENSE file in project root for terms.
+
+package pam
+
+import (
+	"encoding/binary"
+	"errors"
+	"github.com/theparanoids/pam-ysshca/msg"
+	"golang.org/x/sys/unix"
+	"os"
+	"strings"
+	"syscall"
+)
+
+var unknownCommand = []byte("unknown command")
+
+func getCmdLine() []byte {
+	data, err := unix.SysctlRaw("kern.procargs2", os.Getpid())
+	if err != nil {
+		if errors.Is(err, syscall.EINVAL) {
+			// sysctl returns "invalid argument" for both "no such process"
+			// and "operation not permitted" errors.
+			msg.Printlf(msg.WARN, "No such process or operation not permitted: %w", err)
+		}
+		return unknownCommand
+	}
+	return parseKernProcargs2(data)
+}
+
+func parseKernProcargs2(data []byte) []byte {
+	// argc
+	if len(data) < 4 {
+		msg.Printlf(msg.WARN, "Invalid kern.procargs2 data")
+		return unknownCommand
+	}
+	argc := binary.LittleEndian.Uint32(data)
+	data = data[4:]
+
+	// exe
+	lines := strings.Split(string(data), "\x00")
+	exe := lines[0]
+	lines = lines[1:]
+
+	// Skip nulls that may be appended after the exe.
+	for len(lines) > 0 {
+		if lines[0] != "" {
+			break
+		}
+		lines = lines[1:]
+	}
+
+	// argv
+	if c := min(argc, uint32(len(lines))); c > 0 {
+		exe += " "
+		exe += strings.Join(lines[:c], " ")
+	}
+
+	return []byte(exe)
+}
+
+func min(a, b uint32) uint32 {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/pam/cmdline_linux.go
+++ b/pam/cmdline_linux.go
@@ -1,0 +1,29 @@
+// Copyright 2023 Yahoo Inc.
+// Licensed under the terms of the Apache License 2.0. Please see LICENSE file in project root for terms.
+
+package pam
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+func getCmdLine() []byte {
+	cmd, err := ioutil.ReadFile(fmt.Sprintf("/proc/%d/cmdline", os.Getpid()))
+	if err != nil {
+		cmd = []byte("unknown command")
+		msg.Printlf(msg.WARN, "Failed to read /proc/%d/cmdline: %v", os.Getpid(), err)
+	} else if len(cmd) == 0 {
+		cmd = []byte("empty command")
+		msg.Printlf(msg.WARN, "/proc/%d/cmdline is empty", os.Getpid())
+	}
+
+	// Remove '\0' at the end.
+	cmd = cmd[:len(cmd)-1]
+	// Replace '\0' with ' '.
+	cmd = bytes.Replace(cmd, []byte{0}, []byte{' '}, -1)
+
+	return cmd
+}


### PR DESCRIPTION
Use raw syscalls to retrieve the command line under Darwin, since macOS
does not provide a `/proc` filesystem.

The code to do this is from https://github.com/elastic/go-sysinfo which
can be sanity checked against:

https://github.com/apple-oss-distributions/adv_cmds/blob/adv_cmds-205/ps/print.c#L115

I've verified with these changes that `pam_sshca.so` works as expected
under macOS 13 (Ventura) on an arm64 host.

Issues:

1. The Linux `pam.d/sudo` configuration line:

       "auth   [success=done default=die]   pam_sshca.so"

   Does not work on Darwin. Instead use one of the following:

       "auth   requisite   /path/to/pam_sshca.so"

   Or:

       "auth   required   /path/to/pam_sshca.so"

    Neither is identical to `[success=done default=die]` whose
    semantics are impossible under Darwin. See the `pam.conf` man pages
    on Linux and macOS for details.

2. The `log/syslog` module does not work under macOS >= 12 (Monterey).
   Log messages are silently dropped:

   https://github.com/golang/go/issues/59229

3. The `kern.procargs2` syscall returns incorrect data under macOS
   10.15 (Catalina) due to a bug in that OS version. The code won't
   panic under that OS version but it won't return a command line:

   https://github.com/elastic/go-sysinfo/pull/172
