### PR TITLE
Bugfix: Missing imports and formatting for pam/cmdline_*.go

### DIFF
--- a/pam/cmdline_darwin.go
+++ b/pam/cmdline_darwin.go
@@ -6,11 +6,12 @@ package pam
 import (
 	"encoding/binary"
 	"errors"
-	"github.com/theparanoids/pam-ysshca/msg"
-	"golang.org/x/sys/unix"
 	"os"
 	"strings"
 	"syscall"
+
+	"github.com/theparanoids/pam-ysshca/msg"
+	"golang.org/x/sys/unix"
 )
 
 var unknownCommand = []byte("unknown command")

--- a/pam/cmdline_linux.go
+++ b/pam/cmdline_linux.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+
+	"github.com/theparanoids/pam-ysshca/msg"
 )
 
 func getCmdLine() []byte {


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.

This PR addresses the missing msg import for cmdline_linux.go and sorting of imports in cmdline_darwin.go.